### PR TITLE
:bug: Use response data instead of doing another request

### DIFF
--- a/inspector/ios-inspector/ForgeModule/tabs_ConnectionDelegate.h
+++ b/inspector/ios-inspector/ForgeModule/tabs_ConnectionDelegate.h
@@ -14,8 +14,10 @@
 
 @interface ConnectionDelegate : NSObject <NSURLConnectionDelegate, NSURLConnectionDataDelegate> {
     NSMutableDictionary<NSString*, NSNumber*> *authorizationCache;
+    bool _in_basic_auth_flow;
     bool _basic_authorized_failed;
     NSString *pattern;
+    NSURL *currentUrl;
 
     UIWebView *webView;
     tabs_modalWebViewController *modalInstance;


### PR DESCRIPTION
The ConnectionDelegate used to "redo" the current request again,
by calling [webview loadRequest: [connection currentRequest]];

This can mess up stateful authentication flows.

To fix this, we wait for the responseData and load it to the webview:
[webView loadHTMLString:html baseURL:currentUrl];

For testing this, I wrote a little service deployed here: https://basic-auth-test-tmdczuroxn.now.sh

When calling https://basic-auth-test-tmdczuroxn.now.sh/basicAuth it will challenge for credentials ("john", "secret") and redirects to  https://basic-auth-test-tmdczuroxn.now.sh/end after success.

The "end" page lists received request. Without this fix, you see that all requests are performed twice.