### PR TITLE
:bug: Fix auto-close handling via pattern

### DIFF
--- a/inspector/ios-inspector/ForgeModule/tabs_modalWebViewController.h
+++ b/inspector/ios-inspector/ForgeModule/tabs_modalWebViewController.h
@@ -67,6 +67,7 @@
 - (ForgeTask*)getTask;
 - (void)setReturnObj:(NSDictionary *)newReturnObj;
 - (void)setPattern:(NSString *)newPattern;
+- (BOOL)matchesPattern:(NSURL *)urlToCheck;
 - (void)cancel:(id)nothing;
 - (void)stringByEvaluatingJavaScriptFromString:(ForgeTask*)evalTask string:(NSString*)string;
 - (void)close;


### PR DESCRIPTION
If a request fails with error.code == 102, the handling introduced in
e2e23df tries to open the url in an external app (in order to support
downloads and other interactions like adding calendar events).

This broke the auto close behaviour of the tabs-module, which uses the
same error.

So we exclude urls matching the pattern from the open-external-app
handling here.